### PR TITLE
Ueki/sample 20200123 サンプルの実装とメモ

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,16 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+    def find_verified_user
+      verified_user = User.find_by(id: env['warden'].user.id)
+      return reject_unauthorized_connection unless verified_user
+      verified_user
+    end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -7,6 +7,7 @@ module ApplicationCable
     end
 
     private
+
     def find_verified_user
       verified_user = User.find_by(id: env['warden'].user.id)
       return reject_unauthorized_connection unless verified_user

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,6 +1,6 @@
 class RoomChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "room_channel"
+    stream_from "room_channel_#{params['room']}"
   end
 
   def unsubscribed
@@ -8,6 +8,6 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def speak(data)
-    ActionCable.server.broadcast 'room_channel', message: data['message']
+    Message.create! conten: data['message'], user_id: current_user.id, room_id: params['room']
   end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,7 +1,12 @@
 class RoomsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @rooms = Room.all.order(:id)
+  end
+
   def show
-    @messages = Message.all
+    @room = Room.find(params[:id])
+    @messages = @room.messages
   end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,7 +2,7 @@ class RoomsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @rooms = Room.all.order(:id)
+    @rooms = Room.order(:id)
   end
 
   def show

--- a/app/javascript/channels/room_channel.js
+++ b/app/javascript/channels/room_channel.js
@@ -1,29 +1,32 @@
 import consumer from "./consumer"
 
-const chatChannel = consumer.subscriptions.create("RoomChannel", {
-  connected() {
-    // Called when the subscription is ready for use on the server
-  },
+$(function() {
+  const chatChannel = consumer.subscriptions.create("RoomChannel", {
+    connected() {
+      // Called when the subscription is ready for use on the server
+    },
 
-  disconnected() {
-    // Called when the subscription has been terminated by the server
-  },
+    disconnected() {
+      // Called when the subscription has been terminated by the server
+    },
 
-  received(data) {
-    return alert(data['message']);
-  },
+    received(data) {
+      return alert(data['message']);
+    },
 
-  speak: function(message) {
-    return this.perform('speak', {
-      message: message
-    });
-  }
-});
+    speak: function(message) {
+      return this.perform('speak', {
+        message: message
+      });
+    }
+  });
 
-$(document).on('keypress', '[data-behavior~=room_speaker]', function(event) {
-  if (event.keyCode === 13) {
-    chatChannel.speak(event.target.value);
-    event.target.value = '';
-    return event.preventDefault();
-  }
+  $(document).on('keypress', '[data-behavior~=room_speaker]', function(event) {
+    if (event.keyCode === 13) {
+      chatChannel.speak(event.target.value);
+      event.target.value = '';
+      return event.preventDefault();
+    }
+  });
+
 });

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -1,0 +1,3 @@
+def perform(message)
+  ActionCable.server.broadcast "room_channel_#{message.room_id}", message: render_message(message)
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,3 @@
+class Room < ApplicationRecord
+  has_many :messages
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :messages
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,3 +1,3 @@
 .message
   %p
-    = message.content
+    = "#{message.user.email} : #{message.content}"

--- a/app/views/rooms/index.html.haml
+++ b/app/views/rooms/index.html.haml
@@ -1,0 +1,6 @@
+%h1 Rooms#index
+
+%ul
+  - @rooms.each do |room|
+    %li
+      = link_to "ROOM#{room.id}", room_path(room)

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -1,6 +1,7 @@
 %h1 Rooms#show
 %p Find me in app/views/rooms/show.html.haml
-#messages
+
+#messages{data: {room_id: @room.id}}
   = render @messages
 
 = label_tag :content, 'Say something:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   root to: 'rooms#index'
   devise_for :users
 
-  resources :rooms, only: %i[show]
+  resources :rooms, only: %i[index show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  root to: 'rooms#show'
+  root to: 'rooms#index'
   devise_for :users
 
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :rooms, only: %i[show]
 end

--- a/db/migrate/20200123053530_create_rooms.rb
+++ b/db/migrate/20200123053530_create_rooms.rb
@@ -1,0 +1,8 @@
+class CreateRooms < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rooms do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200123053642_add_user_ref_and_room_ref_to_messages.rb
+++ b/db/migrate/20200123053642_add_user_ref_and_room_ref_to_messages.rb
@@ -1,0 +1,6 @@
+class AddUserRefAndRoomRefToMessages < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :messages, :user, null: false, foreign_key: true
+    add_reference :messages, :room, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_132925) do
+ActiveRecord::Schema.define(version: 2020_01_23_053642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "messages", force: :cascade do |t|
     t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "rooms", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -33,4 +42,6 @@ ActiveRecord::Schema.define(version: 2020_01_21_132925) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
ActionCableのサンプルアプリ、[【Rails6\.0】ActionCableとDeviseの欲張りセットでリアルタイムチャット作成\(改正版\) \- Qiita](https://qiita.com/eRy-sk/items/4c4e983e34a44c5ace27#%E5%85%A5%E5%8A%9B%E3%81%97%E3%81%9F%E3%82%82%E3%81%AE%E3%81%8C%E4%BF%9D%E5%AD%98%E3%81%95%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E6%94%B9%E5%96%84)の続きです。


## メモ
```js
$(document).on('keypress', '[data-behavior~=room_speaker]', function(event) {
```

- `~=`はjqueryの機能で、[指定した値が単語として属性の値に含まれる要素を選択](http://www.jquerystudy.info/reference/selectors/containsWord.html)する

## haml的に書くとチェーンケースに直されてハマったこと

サンプルのこの部分を、
```show.html.erb
<div id="messages", data-room_id="<%= @room.id %>">
```
Hamlでこう書くと、
```show.html.haml
#messages{ data: { 'room_id': @room.id } }
```
HTMLが以下のようになる。
`data-room_id`のつもりが、`data-room-id`になっている。
```html
<div data-room-id="1" id="messages">
</div>
```
js側でこの属性名を探す部分があり、不整合をおこしていてメッセージが表示されなくなってハマりました。


`#messages{ 'data-room_id': @room.id }` と書くか、
Hamlに寄せるのであれば、`#messages{ data: { room: { id: @room.id } } }` と書いて、

`room_channel.js`を以下に変えればよさそうです。
```diff
- room: $('#messages').data('room_id')
+ room: $('#messages').data('room-id')
```